### PR TITLE
Improve compatibility with newer PHP

### DIFF
--- a/includes/admin.class.php
+++ b/includes/admin.class.php
@@ -47,7 +47,7 @@ class sgAdmin extends Singapore
    * Admin constructor. Doesn't call {@link Singapore} constructor.
    * @param string the path to the base singapore directory
    */
-  function sgAdmin($basePath = "")
+  public function __construct($basePath = "")
   {
     //import class definitions
     //io handler class included once config is loaded

--- a/includes/admin.class.php
+++ b/includes/admin.class.php
@@ -61,17 +61,6 @@ class sgAdmin extends Singapore
     //start execution timer
     $this->scriptStartTime = microtime();
 
-    //remove slashes
-    if(get_magic_quotes_gpc()) {
-      $_REQUEST = array_map(array("Singapore","arraystripslashes"), $_REQUEST);
-      
-      //as if magic_quotes_gpc wasn't insane enough, php doesn't add slashes 
-      //to the tmp_name variable so I have to add them manually. Grrrr.
-      foreach($_FILES as $key => $nothing)
-        $_FILES[$key]["tmp_name"] = addslashes($_FILES[$key]["tmp_name"]);
-      $_FILES   = array_map(array("Singapore","arraystripslashes"), $_FILES);
-    }
-    
     $galleryId = isset($_REQUEST["gallery"]) ? $_REQUEST["gallery"] : ".";
     
     //load config from singapore root directory

--- a/includes/config.class.php
+++ b/includes/config.class.php
@@ -24,7 +24,7 @@ class sgConfig
    * Implements the Singleton design pattern by always returning a reference
    * to the same sgConfig object. Use instead of 'new'.
    */
-  function &getInstance()
+  static function &getInstance()
   {
     static $instance;
     if(!is_object($instance))

--- a/includes/config.class.php
+++ b/includes/config.class.php
@@ -35,23 +35,23 @@ class sgConfig
   }
   
   /**
-	 * Parses an ini file for configuration directives and imports the values 
-	 * into the current object overwriting any previous values.
-	 * @param string relative or absolute path to the ini file to load
-	 * @return boolean true on success; false otherwise
-	 */
-	function loadConfig($configFilePath)
-	{
-	  if(!file_exists($configFilePath)) return false;
-	  
-	  //get values from ini file
+   * Parses an ini file for configuration directives and imports the values
+   * into the current object overwriting any previous values.
+   * @param string relative or absolute path to the ini file to load
+   * @return boolean true on success; false otherwise
+   */
+  function loadConfig($configFilePath)
+  {
+    if(!file_exists($configFilePath)) return false;
+
+    //get values from ini file
     $ini_values = parse_ini_file($configFilePath);
 
     //import values into object scope
     foreach($ini_values as $key => $value) $this->$key = $value;
  
     return true;
-	}
+  }
 }
 
 ?>

--- a/includes/gallery.class.php
+++ b/includes/gallery.class.php
@@ -53,7 +53,7 @@ class sgGallery extends sgItem
    * @param string     gallery id
    * @param sgGallery  reference to the parent gallery
    */
-  function sgGallery($id, &$parent)
+  public function __construct($id, &$parent)
   {
     $this->id = $id;
     $this->parent = $parent;

--- a/includes/gallery.class.php
+++ b/includes/gallery.class.php
@@ -53,7 +53,7 @@ class sgGallery extends sgItem
    * @param string     gallery id
    * @param sgGallery  reference to the parent gallery
    */
-  public function __construct($id, &$parent)
+  public function __construct($id, $parent)
   {
     $this->id = $id;
     $this->parent = $parent;

--- a/includes/image.class.php
+++ b/includes/image.class.php
@@ -53,7 +53,7 @@ class sgImage extends sgItem
    * @param string     image id
    * @param sgGallery  reference to the parent gallery
    */
-  public function __construct($id, &$parent)
+  public function __construct($id, $parent)
   {
     $this->id = $id;
     $this->parent = $parent;

--- a/includes/image.class.php
+++ b/includes/image.class.php
@@ -53,7 +53,7 @@ class sgImage extends sgItem
    * @param string     image id
    * @param sgGallery  reference to the parent gallery
    */
-  function sgImage($id, &$parent)
+  public function __construct($id, &$parent)
   {
     $this->id = $id;
     $this->parent = $parent;

--- a/includes/io.class.php
+++ b/includes/io.class.php
@@ -28,7 +28,7 @@ class sgIO
    * Constructor. Can be over-ridden by subclass but does not need to be.
    * @param sgConfig  pointer to current script configuration object
    */
-  function sgIO()
+  public function __construct()
   {
     $this->config = sgConfig::getInstance();
   }

--- a/includes/io_csv.class.php
+++ b/includes/io_csv.class.php
@@ -208,7 +208,7 @@ class sgIO_csv extends sgIO
    * Fetches hit data from file.
    * @param sgGallery  gallery object to load hits into
    */
-  function getHits(&$gal) {
+  function getHits($gal) {
     
     $fp = @fopen($this->config->base_path.$this->config->pathto_galleries.$gal->id."/hits.csv","r");
     

--- a/includes/io_mysql.class.php
+++ b/includes/io_mysql.class.php
@@ -22,7 +22,7 @@ class sgIO_mysql extends sgIOsql
    * @param sgConfig pointer to a {@link sgConfig} object representing 
    *   the current script configuration
    */
-  function sgIO_mysql()
+  public function __construct()
   {
     $this->config = sgConfig::getInstance();
     mysql_connect($this->config->sql_host, $this->config->sql_user, $this->config->sql_pass);

--- a/includes/io_sqlite.class.php
+++ b/includes/io_sqlite.class.php
@@ -27,7 +27,7 @@ class sgIO_sqlite extends sgIOsql
    * @param sgConfig pointer to a {@link sgConfig} object representing 
    *   the current script configuration
    */
-  function sgIO_sqlite()
+  public function __construct()
   {
     $this->config = sgConfig::getInstance();
     $this->db = sqlite_open($this->config->base_path.$this->config->pathto_data_dir."sqlite.dat");

--- a/includes/singapore.class.php
+++ b/includes/singapore.class.php
@@ -85,7 +85,7 @@ class Singapore
    * Constructor, does all init type stuff. This code is a total mess.
    * @param string the path to the base singapore directory
    */
-  function Singapore($basePath = "")
+  public function __construct($basePath = "")
   {
     //import class definitions
     //io handler class included once config is loaded

--- a/includes/singapore.class.php
+++ b/includes/singapore.class.php
@@ -822,7 +822,7 @@ class Singapore
   /**
    * Slightly pointless method
    */
-  function conditional($conditional, $iftrue, $iffalse = null)
+  static function conditional($conditional, $iftrue, $iffalse = null)
   {
     if($conditional) return sprintf($iftrue, $conditional);
     elseif($iffalse != null) return sprintf($iffalse, $conditional);
@@ -833,7 +833,7 @@ class Singapore
    * Callback function for recursively stripping slashes
    * @static
    */
-  function arraystripslashes($toStrip)
+  static function arraystripslashes($toStrip)
   {
     if(is_array($toStrip))
       return array_map(array("Singapore","arraystripslashes"), $toStrip);
@@ -841,7 +841,7 @@ class Singapore
       return stripslashes($toStrip);
   }
   
-  function thumbnailPath($gallery, $image, $width, $height, $forceSize, $mode = 1)
+  static function thumbnailPath($gallery, $image, $width, $height, $forceSize, $mode = 1)
   {
     $config = sgConfig::getInstance();
     switch($mode) {
@@ -859,7 +859,7 @@ class Singapore
    * @returns stdClass|false  a data object representing the directory and its contents
    * @static
    */
-  function getListing($wd, $mask = null, $getHidden = false)
+  static function getListing($wd, $mask = null, $getHidden = false)
   {
     $dir = new stdClass;
     $dir->path = realpath($wd)."/";
@@ -957,7 +957,7 @@ class Singapore
    * @param bool    set false to prevent canonicalisation of paths (optional)
    * @return bool   true if $child is contained within or is $parent 
    */
-  function isSubPath($parent, $child, $canonicalise = true) 
+  static function isSubPath($parent, $child, $canonicalise = true)
   {
     $parentPath = $canonicalise ? realpath($parent) : $parent;
     $childPath = $canonicalise ? realpath($child) : $child;
@@ -965,7 +965,7 @@ class Singapore
   }
 
 
-  function isInGroup($groups1,$groups2) 
+  static function isInGroup($groups1,$groups2)
   {
     return (bool) array_intersect(explode(" ",$groups1),explode(" ",$groups2)); 
   }

--- a/includes/singapore.class.php
+++ b/includes/singapore.class.php
@@ -201,7 +201,7 @@ class Singapore
     if(empty($galleryId)) $galleryId = isset($_REQUEST[$this->config->url_gallery]) ? $_REQUEST[$this->config->url_gallery] : ".";
     
     //try to validate gallery id
-    if(strlen($galleryId)>1 && $galleryId{1} != '/') $galleryId = './'.$galleryId;
+    if(strlen($galleryId)>1 && $galleryId[1] != '/') $galleryId = './'.$galleryId;
     
     //detect back-references to avoid file-system walking
     if(strpos($galleryId,"../")!==false) $galleryId = ".";
@@ -872,7 +872,7 @@ class Singapore
     while(false !== ($entry = readdir($dp)))
       if(is_dir($dir->path.$entry)) {
         if($entry    != "CVS" && $entry    != ".svn" && 
-         (($entry{0} != '.'   && $entry{0} != '_')   || $getHidden))
+         (($entry[0] != '.'   && $entry[0] != '_')   || $getHidden))
           $dir->dirs[] = $entry;
       } else {
         if($mask == null || preg_match("/\.($mask)$/i",$entry))

--- a/includes/singapore.class.php
+++ b/includes/singapore.class.php
@@ -99,10 +99,6 @@ class Singapore
     //start execution timer
     $this->scriptStartTime = microtime();
     
-    //remove slashes
-    if(get_magic_quotes_gpc())
-      $_REQUEST = array_map(array("Singapore","arraystripslashes"), $_REQUEST);
-    
     //desanitize request
     $_REQUEST = array_map("htmlentities", $_REQUEST);
     

--- a/includes/thumbnail.class.php
+++ b/includes/thumbnail.class.php
@@ -29,7 +29,7 @@ class sgThumbnail
   var $imagePath = "";
   var $thumbPath = "";
   
-  function sgThumbnail(&$img, $type)
+  public function __construct(&$img, $type)
   {
     $this->config = sgConfig::getInstance();
     $this->image  = $img; 

--- a/includes/translator.class.php
+++ b/includes/translator.class.php
@@ -43,7 +43,7 @@ class Translator
    * @param string  language code (optional)
    * @static
    */
-  function &getInstance($language = 0)
+  static function &getInstance($language = 0)
   {
     static $instances = array();
     

--- a/includes/translator.class.php
+++ b/includes/translator.class.php
@@ -31,7 +31,7 @@ class Translator
    * @param string  language code
    * @private
    */
-  function Translator($language)
+  public function __construct($language)
   {
     $this->language = $language;
   }

--- a/includes/user.class.php
+++ b/includes/user.class.php
@@ -68,7 +68,7 @@ class sgUser
   /**
    * Constructor ensures username and userpass have values
    */
-  function sgUser($username, $userpass)
+  public function __construct($username, $userpass)
   {
     $this->username = $username;
     $this->userpass = $userpass;


### PR DESCRIPTION
* Mark static functions as such with the "static" keyword
* Use __construct to name constructors
* sgIO_csv: match the getHits signature of the parent
* Use square brackets to access array items
* Remove the usage of get_magic_quotes_gpc
* Config class: reformat a bit, fix indentation